### PR TITLE
Update Broccoli to 0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "author": "Thomas Boyt <me@thomasboyt.com>",
   "license": "MIT",
   "dependencies": {
+    "broccoli": "^0.13.3",
+    "copy-dereference": "^1.0.0",
+    "karma": "^0.12.10",
     "rimraf": "^2.2.6",
-    "ncp": "^0.5.1",
-    "rsvp": "^3.0.6",
-    "broccoli": "^0.9.0",
-    "karma": "^0.12.10"
+    "rsvp": "^3.0.6"
   },
   "devDependencies": {},
   "repository": {

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,10 @@
-var fs = require('fs');
 var RSVP = require('rsvp');
-var ncp = require('ncp');
 var rimraf = require('rimraf');
+var copyDereferenceSync = require('copy-dereference').sync;
 
 function copyDir(dir, outputDir) {
   try {
-    fs.mkdirSync(outputDir);
+    copyDereferenceSync(dir, outputDir);
   } catch (err) {
     if (err.code !== 'EEXIST') {
       throw err;
@@ -13,10 +12,6 @@ function copyDir(dir, outputDir) {
     console.error('Error: Directory "' + outputDir + '" already exists. Refusing to overwrite files.');
     process.exit(1);
   }
-  return RSVP.denodeify(ncp)(dir, outputDir, {
-    clobber: false,
-    stopOnErr: true
-  });
 }
 
 function rmDir(dir) {


### PR DESCRIPTION
This PR updates Broccoli to the latest version and performs a few related changes.

Since Broccoli now uses symlinks to speed up the build process, we need to dereference symlinks when copying files into the output directory. It's done using `copy-dereference`, a tool by Broccoli authors. It's synchronous, so we don't need to use promises.

Watcher doesn't trigger the `change` event twice anymore at the beginning of the build.

Quickly triggering multiple `change` events will now result only in one execution of karma. Triggering `change` events while karma is running will correctly execute the handler only after karma exits.
